### PR TITLE
Update create issue links

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -17,13 +17,13 @@ to all Jazzband members but only to those who have shown significant
 contributions to the projects in question. All other Jazzband features
 (as of writing this) continue to be open to all Jazzband members.
 
-To become a project lead, please also [open an issue with the
-"lead" label](/roadies/issue?labels=lead).
+To become a project lead, please also
+[open a project lead issue](/roadies/issue).
 
 In case no project lead(s) can be found for a project the [roadies]
 will act as surrogate leads and can be contacted to request a PyPI
 release on the behalf of the Jazzband members. Please
-[open a ticket with a "pypi" label](/roadies/issue?labels=pypi) for that.
+[open a PyPI Release ticket](/roadies/issue) for that.
 
 !!! note "Why are there project leads?"
 
@@ -80,7 +80,7 @@ Steps needed:
 
 - Set up the `.travis.yml` file following the  [Travis CI docs][travis-python].
 - Create a `tox.ini` which takes [tox-travis] into account.
-- [Open an issue](/roadies/issue?labels=pypi) for the
+- [Open a PyPI Release issue](/roadies/issue) for the
   roadies to enable the auto-release mechanism via the Jazzband.
 
 If you need a project release and you are not a project lead, you

--- a/jazzband/members/views.py
+++ b/jazzband/members/views.py
@@ -23,9 +23,3 @@ def roadies():
 def roadies_issue():
     url = "https://github.com/jazzband-roadies/help/issues/new/choose"
     return redirect(url)
-
-
-@members.route("/website/issue")
-def website_issue():
-    url = "https://github.com/jazzband-roadies/website/issues/new"
-    return redirect(url)

--- a/jazzband/members/views.py
+++ b/jazzband/members/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, redirect, request
+from flask import Blueprint, redirect
 from sqlalchemy.sql.expression import func
 
 from ..decorators import templated
@@ -21,8 +21,11 @@ def roadies():
 
 @members.route("/roadies/issue")
 def roadies_issue():
-    labels = request.args.get("labels", None)
-    url = "https://github.com/jazzband-roadies/help/issues/new"
-    if labels:
-        url += f"?labels={labels}"
+    url = "https://github.com/jazzband-roadies/help/issues/new/choose"
+    return redirect(url)
+
+
+@members.route("/website/issue")
+def website_issue():
+    url = "https://github.com/jazzband-roadies/website/issues/new"
     return redirect(url)

--- a/jazzband/templates/error.html
+++ b/jazzband/templates/error.html
@@ -4,7 +4,7 @@
 <div class="c4">
   <h2>Error</h2>
   <p>Looks like something went wrong.</p>
-  <p>Please <a href="/roadies/issue?labels=bug">open an issue</a> for the roadies if the problem persists.</p>
+  <p>Please <a href="/website/issue">open an issue</a> for the roadies if the problem persists.</p>
   {% if g.sentry_event_id %}
   <p>The error identifier is {{ g.sentry_event_id }}</p>
   {% endif %}

--- a/jazzband/templates/error.html
+++ b/jazzband/templates/error.html
@@ -4,7 +4,7 @@
 <div class="c4">
   <h2>Error</h2>
   <p>Looks like something went wrong.</p>
-  <p>Please <a href="/website/issue">open an issue</a> for the roadies if the problem persists.</p>
+  <p>Please <a href="/roadies/issue">open an issue</a> for the roadies if the problem persists.</p>
   {% if g.sentry_event_id %}
   <p>The error identifier is {{ g.sentry_event_id }}</p>
   {% endif %}

--- a/jazzband/templates/members/roadies.html
+++ b/jazzband/templates/members/roadies.html
@@ -13,7 +13,7 @@
   </p>
   <p>
     You can get in touch with the roadies by
-    <a href="/roadies/issue?labels=question" title="opening an issue">opening an issue</a>
+    <a href="/roadies/issue" title="opening an issue">opening an issue</a>
     on GitHub.
   </p>
 

--- a/jazzband/templates/projects/detail.html
+++ b/jazzband/templates/projects/detail.html
@@ -91,7 +91,7 @@
     <p>
       Please refer to the
       <a href="/about/releases">releases documentation</a> for more information about the release process. If you have any question, please file a
-      <a href="/roadies/issue?labels=pypi">new issue for the roadies
+      <a href="/roadies/issue">new PyPI Release issue for the roadies
       </a> with the label "PyPI" or
       <a href="/about/contact">contact</a>
       us directly.

--- a/jazzband/templates/projects/mails/new_upload_notification.txt
+++ b/jazzband/templates/projects/mails/new_upload_notification.txt
@@ -62,7 +62,7 @@ security@jazzband.co
 
 If you need help please file a ticket with the roadies here:
 
-https://jazzband.co/roadies/issue?labels=pypi
+https://jazzband.co/roadies/issue
 
 Or contact them in any other way:
 
@@ -75,4 +75,4 @@ Thanks for your help and remember: We are all part of this.
 
 PS: You're receiving this email because you are a member of the project "{{ project.name }}" maintained by the Jazzband: https://jazzband.co/
 
-PPS: If you want to unsubscribe from this kind of email please go to https://jazzband.co/roadies/issue?labels=bug and let us know that you would like to be removed from the project.
+PPS: If you want to unsubscribe from this kind of email please go to https://jazzband.co/roadies/issue and let us know that you would like to be removed from the project.


### PR DESCRIPTION
Closes https://github.com/jazzband-roadies/website/issues/730

- The old logic would open an issue with a label get parameter, however this didn't work (see https://github.com/jazzband-roadies/help/issues/188)
- Instead, we have added some issue templates (https://github.com/jazzband-roadies/help/pull/197)
- The URL to view the template selection is /issues/new/choose
- This PR removed the logic for handling, and instead takes users directly to the template selection page.
- Strangely, choosing one of these templates seems to add most options into the get params (including labels), but somehow it gets around the permissions issue.
- ~I have also changed the link for if the website is erroring to create an issue on the website repo, rather than the help repo.~  (edit: removed this change in code review)

Note: I could have linked to the resulting issues page once you'd chosen your selection (e.g. "Project lead"), but there are multiple get parameters, and some would need updating if we change the template. I think it's better like this, so we can update the templates without making any other changes. Let me know if you disagree.