### PR TITLE
Don't use SSL in dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: flask run -h 0.0.0.0 -p 5000 --cert=adhoc
+web: flask run -h 0.0.0.0 -p 5000
 worker: flask spinach


### PR DESCRIPTION
This gets around the SSL issue in development by simply not using SSL in dev.

The issue with SSL is that browsers don't like the `adhoc` certificate, and display a bit warning.

Feel free to close if this isn't the correct fix...