### PR TITLE
Don't show 'There is currently only one version:' when 0 versions

### DIFF
--- a/jazzband/templates/projects/detail.html
+++ b/jazzband/templates/projects/detail.html
@@ -104,7 +104,7 @@
   <p>
     {% if versions|count > 1 %}
     There are currently {{ versions|count }} versions:
-    {% else %}
+    {% elif versions|count == 1 %}
     There is currently only one version:
     {% endif %}
     {% for version in versions %}


### PR DESCRIPTION
https://jazzband.co/projects/prettytable has no releases yet, and shows:

![image](https://user-images.githubusercontent.com/1324225/94938024-0009f900-04d9-11eb-9cb2-9a57a412c221.png)

This PR changes it so "There is currently only one version:" is only shown when there's only 1 version.

When there's 0, only show "No uploads found for this project."
